### PR TITLE
Add default value for tx_abtest2_b_id field

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -9,7 +9,8 @@
             'internal_type' => 'db',
             'allowed' => 'pages',
             'maxitems' => 1,
-            'size' => 1
+            'size' => 1,
+            'default' => 0
         ]
     ],
     'tx_abtest2_cookie_time' => [


### PR DESCRIPTION
When removing connection to B page, default value is required, otherwise it is not possible to save changes on page and remove A/B testing